### PR TITLE
Move the position of the queue length in the title

### DIFF
--- a/src/pages/sessions/[id]/manage/index.tsx
+++ b/src/pages/sessions/[id]/manage/index.tsx
@@ -340,7 +340,7 @@ const ManageSessionPage: NextPage = () => {
     return (
       <div>
         <Head>
-          <title key="title">{`${title} (${sessionDataQuery.data.inQueue.length})`}</title>
+          <title key="title">{`(${sessionDataQuery.data.inQueue.length}) ${title}`}</title>
         </Head>
         <h2>{sessionDataQuery.data.name}</h2>
         <h4>{sessionDataQuery.data.locations.join(", ")}</h4>


### PR DESCRIPTION
Currently it's quite easy to miss when someone is in the queue if you don't have the tab selected. By moving the length to the beginning of the title, the assistant can see the queue length (and notice when someone joins) even if the tab is not selected.